### PR TITLE
Fix namespace genes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: bumphunter
-Version: 1.25.4
+Version: 1.26.0
 Title: Bump Hunter
 Description: Tools for finding bumps in genomic data
 Authors@R: c(person(c("Rafael", "A."), "Irizarry", role = c("cre","aut"), email

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: bumphunter
-Version: 1.27.0
+Version: 1.27.1
 Title: Bump Hunter
 Description: Tools for finding bumps in genomic data
 Authors@R: c(person(c("Rafael", "A."), "Irizarry", role = c("cre","aut"), email

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: bumphunter
-Version: 1.26.0
+Version: 1.27.0
 Title: Bump Hunter
 Description: Tools for finding bumps in genomic data
 Authors@R: c(person(c("Rafael", "A."), "Irizarry", role = c("cre","aut"), email

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -16,14 +16,14 @@ importMethodsFrom(IRanges, as.list, as.matrix,
                   resize, runmed, start,
                   which, which.min, width)
 importFrom(IRanges, CharacterList, IRanges)
-importFrom(GenomeInfoDb, seqnames)
+importFrom(GenomeInfoDb, seqnames, seqinfo)
 importFrom(GenomicRanges, GRanges, makeGRangesFromDataFrame)
 importMethodsFrom(GenomicRanges, sort)
 importFrom(locfit, locfit)
 importFrom(locfit, lp)
 importFrom(utils, data, packageDescription)
 importFrom(parallel, mclapply, stopCluster)
-importFrom(GenomicFeatures, exonsBy, cdsBy, transcriptsBy)
+importFrom(GenomicFeatures, exonsBy, cdsBy, transcriptsBy, genes)
 importFrom(AnnotationDbi, mappedkeys)
 importMethodsFrom(AnnotationDbi, mapIds)
 


### PR DESCRIPTION
Hi,

This PR first syncs the repo with the Bioconductor one following http://bioconductor.org/developers/how-to/git/sync-existing-repositories/ and then fixes the NAMESPACE issues detected by the use case at https://github.com/rafalab/bumphunter/issues/25.

Best,
Leo


```R
> library(GenomicState)
> txdb_v31_hg38_chr22 <- gencode_txdb(chrs = 'chr22')
2019-10-03 17:27:36 importing ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_31/gencode.v31.annotation.gtf.gz
trying URL 'ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_31/gencode.v31.annotation.gtf.gz'
Content type 'unknown' length 42824232 bytes (40.8 MB)
==================================================
2019-10-03 17:29:01 keeping relevant chromosomes
2019-10-03 17:29:01 preparing metadata
Prepare the 'metadata' data frame ... OK
2019-10-03 17:29:12 building the txdb object
Warning messages:
1: In rep(as.integer(len), length = length(str)) :
  partial argument match of 'length' to 'length.out'
2: In .get_cds_IDX(mcols0$type, mcols0$phase) :
  The "phase" metadata column contains non-NA values for features of type stop_codon. This information was
  ignored.
3: In .local(conn, statement, ...) :
  partial argument match of 'param' to 'params'
> genes_v31_hg38_chr22 <- gencode_annotated_genes(txdb_v31_hg38_chr22)
2019-10-03 17:29:16 annotating the transcripts
No annotationPackage supplied. Trying org.Hs.eg.db.
Loading required package: org.Hs.eg.db
Loading required package: AnnotationDbi
Loading required package: stats4
Loading required package: BiocGenerics
Loading required package: parallel

Attaching package: ‘BiocGenerics’

The following objects are masked from ‘package:parallel’:

    clusterApply, clusterApplyLB, clusterCall, clusterEvalQ, clusterExport, clusterMap, parApply,
    parCapply, parLapply, parLapplyLB, parRapply, parSapply, parSapplyLB

The following objects are masked from ‘package:stats’:

    IQR, mad, sd, var, xtabs

The following objects are masked from ‘package:base’:

    anyDuplicated, append, as.data.frame, basename, cbind, colnames, dirname, do.call, duplicated, eval,
    evalq, Filter, Find, get, grep, grepl, intersect, is.unsorted, lapply, Map, mapply, match, mget, order,
    paste, pmax, pmax.int, pmin, pmin.int, Position, rank, rbind, Reduce, rownames, sapply, setdiff, sort,
    table, tapply, union, unique, unsplit, which, which.max, which.min

Loading required package: Biobase
Welcome to Bioconductor

    Vignettes contain introductory material; view with 'browseVignettes()'. To cite Bioconductor, see
    'citation("Biobase")', and for packages 'citation("pkgname")'.

Loading required package: IRanges
Loading required package: S4Vectors

Attaching package: ‘S4Vectors’

The following object is masked from ‘package:base’:

    expand.grid


Getting TSS and TSE.
Getting CSS and CSE.
Getting exons.
Annotating genes.
'select()' returned 1:many mapping between keys and columns
> options(width = 120)
> sessioninfo::session_info()
─ Session info ───────────────────────────────────────────────────────────────────────────────────────────────────────
 setting  value                       
 version  R version 3.6.1 (2019-07-05)
 os       macOS Mojave 10.14.6        
 system   x86_64, darwin15.6.0        
 ui       RStudio                     
 language (EN)                        
 collate  en_US.UTF-8                 
 ctype    en_US.UTF-8                 
 tz       America/New_York            
 date     2019-10-03                  

─ Packages ───────────────────────────────────────────────────────────────────────────────────────────────────────────
 package              * version   date       lib source                            
 AnnotationDbi        * 1.46.1    2019-08-20 [1] Bioconductor                      
 assertthat             0.2.1     2019-03-21 [1] CRAN (R 3.6.0)                    
 backports              1.1.4     2019-04-10 [1] CRAN (R 3.6.0)                    
 bibtex                 0.4.2     2017-06-30 [1] CRAN (R 3.6.0)                    
 Biobase              * 2.44.0    2019-05-02 [1] Bioconductor                      
 BiocGenerics         * 0.30.0    2019-05-02 [1] Bioconductor                      
 BiocParallel           1.18.1    2019-08-06 [1] Bioconductor                      
 biomaRt                2.40.4    2019-08-19 [1] Bioconductor                      
 Biostrings             2.52.0    2019-05-02 [1] Bioconductor                      
 bit                    1.1-14    2018-05-29 [1] CRAN (R 3.6.0)                    
 bit64                  0.9-7     2017-05-08 [1] CRAN (R 3.6.0)                    
 bitops                 1.0-6     2013-08-17 [1] CRAN (R 3.6.0)                    
 blob                   1.2.0     2019-07-09 [1] CRAN (R 3.6.0)                    
 bumphunter             1.27.1    2019-10-03 [1] Bioconductor                      
 callr                  3.3.2     2019-09-22 [1] CRAN (R 3.6.1)                    
 cli                    1.1.0     2019-03-19 [1] CRAN (R 3.6.0)                    
 codetools              0.2-16    2018-12-24 [1] CRAN (R 3.6.1)                    
 colorout             * 1.2-1     2019-05-07 [1] Github (jalvesaq/colorout@7ea9440)
 crayon                 1.3.4     2017-09-16 [1] CRAN (R 3.6.0)                    
 DBI                    1.0.0     2018-05-02 [1] CRAN (R 3.6.0)                    
 DelayedArray           0.10.0    2019-05-02 [1] Bioconductor                      
 desc                   1.2.0     2018-05-01 [1] CRAN (R 3.6.0)                    
 devtools             * 2.2.1     2019-09-24 [1] CRAN (R 3.6.1)                    
 digest                 0.6.21    2019-09-20 [1] CRAN (R 3.6.0)                    
 doRNG                  1.7.1     2018-06-22 [1] CRAN (R 3.6.0)                    
 ellipsis               0.3.0     2019-09-20 [1] CRAN (R 3.6.0)                    
 foreach                1.4.7     2019-07-27 [1] CRAN (R 3.6.0)                    
 fs                     1.3.1     2019-05-06 [1] CRAN (R 3.6.0)                    
 GenomeInfoDb           1.20.0    2019-05-02 [1] Bioconductor                      
 GenomeInfoDbData       1.2.1     2019-04-10 [1] Bioconductor                      
 GenomicAlignments      1.20.1    2019-06-18 [1] Bioconductor                      
 GenomicFeatures        1.36.4    2019-07-09 [1] Bioconductor                      
 GenomicRanges          1.36.1    2019-09-06 [1] Bioconductor                      
 GenomicState         * 0.99.0    2019-10-03 [1] Bioconductor                      
 glue                   1.3.1     2019-03-12 [1] CRAN (R 3.6.0)                    
 hms                    0.5.1     2019-08-23 [1] CRAN (R 3.6.0)                    
 httr                   1.4.1     2019-08-05 [1] CRAN (R 3.6.0)                    
 IRanges              * 2.18.3    2019-09-24 [1] Bioconductor                      
 iterators              1.0.12    2019-07-26 [1] CRAN (R 3.6.1)                    
 lattice                0.20-38   2018-11-04 [1] CRAN (R 3.6.1)                    
 locfit                 1.5-9.1   2013-04-20 [1] CRAN (R 3.6.0)                    
 magrittr               1.5       2014-11-22 [1] CRAN (R 3.6.0)                    
 Matrix                 1.2-17    2019-03-22 [1] CRAN (R 3.6.1)                    
 matrixStats            0.55.0    2019-09-07 [1] CRAN (R 3.6.0)                    
 memoise                1.1.0     2017-04-21 [1] CRAN (R 3.6.0)                    
 org.Hs.eg.db         * 3.8.2     2019-05-07 [1] Bioconductor                      
 packrat                0.5.0     2018-11-14 [1] CRAN (R 3.6.0)                    
 pillar                 1.4.2     2019-06-29 [1] CRAN (R 3.6.0)                    
 pkgbuild               1.0.5     2019-08-26 [1] CRAN (R 3.6.1)                    
 pkgconfig              2.0.3     2019-09-22 [1] CRAN (R 3.6.1)                    
 pkgload                1.0.2     2018-10-29 [1] CRAN (R 3.6.0)                    
 pkgmaker               0.27      2018-05-25 [1] CRAN (R 3.6.0)                    
 prettyunits            1.0.2     2015-07-13 [1] CRAN (R 3.6.0)                    
 processx               3.4.1     2019-07-18 [1] CRAN (R 3.6.0)                    
 progress               1.2.2     2019-05-16 [1] CRAN (R 3.6.0)                    
 ps                     1.3.0     2018-12-21 [1] CRAN (R 3.6.0)                    
 R6                     2.4.0     2019-02-14 [1] CRAN (R 3.6.0)                    
 Rcpp                   1.0.2     2019-07-25 [1] CRAN (R 3.6.0)                    
 RCurl                  1.95-4.12 2019-03-04 [1] CRAN (R 3.6.0)                    
 registry               0.5-1     2019-03-05 [1] CRAN (R 3.6.0)                    
 remotes                2.1.0     2019-06-24 [1] CRAN (R 3.6.0)                    
 rlang                  0.4.0     2019-06-25 [1] CRAN (R 3.6.0)                    
 rngtools               1.4       2019-07-01 [1] CRAN (R 3.6.0)                    
 rprojroot              1.3-2     2018-01-03 [1] CRAN (R 3.6.0)                    
 Rsamtools              2.0.1     2019-09-19 [1] Bioconductor                      
 RSQLite                2.1.2     2019-07-24 [1] CRAN (R 3.6.0)                    
 rstudioapi             0.10      2019-03-19 [1] CRAN (R 3.6.0)                    
 rtracklayer            1.44.4    2019-09-06 [1] Bioconductor                      
 S4Vectors            * 0.22.1    2019-09-09 [1] Bioconductor                      
 sessioninfo            1.1.1     2018-11-05 [1] CRAN (R 3.6.0)                    
 stringi                1.4.3     2019-03-12 [1] CRAN (R 3.6.0)                    
 stringr                1.4.0     2019-02-10 [1] CRAN (R 3.6.0)                    
 SummarizedExperiment   1.14.1    2019-07-31 [1] Bioconductor                      
 testthat             * 2.2.1     2019-07-25 [1] CRAN (R 3.6.0)                    
 tibble                 2.1.3     2019-06-06 [1] CRAN (R 3.6.0)                    
 usethis              * 1.5.1     2019-07-04 [1] CRAN (R 3.6.0)                    
 vctrs                  0.2.0     2019-07-05 [1] CRAN (R 3.6.0)                    
 withr                  2.1.2     2018-03-15 [1] CRAN (R 3.6.0)                    
 XML                    3.98-1.20 2019-06-06 [1] CRAN (R 3.6.0)                    
 xtable                 1.8-4     2019-04-21 [1] CRAN (R 3.6.0)                    
 XVector                0.24.0    2019-05-02 [1] Bioconductor                      
 zeallot                0.1.0     2018-01-28 [1] CRAN (R 3.6.0)                    
 zlibbioc               1.30.0    2019-05-02 [1] Bioconductor                      

[1] /Library/Frameworks/R.framework/Versions/3.6/Resources/library
> 
```